### PR TITLE
feat: Centralize data storage in a single Google Sheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,12 @@
 
     // app state
     let settings = {}
-    let state = { customers: [] }
+    let state = { customers: [] } // This will hold the data for the *current* user
+    let masterState = {}; // This will hold data for ALL users, loaded from Sheets
+
+    // --- Google Sheets API Config ---
+    const API_KEY = "AIzaSyDQwyJSyh2DspLC-NfKfi5z5NAVxxc4QCA";
+    const SPREADSHEET_ID = "1PYPBDN1l4--LzbeLRPRb8DIvNcBdh0YrmfyFyN_0bBQ";
 
     // --- FIXED: All UI refs are now defined here ---
     const customerList = document.getElementById('customerList')
@@ -270,20 +275,25 @@
             }
             const authData = JSON.parse(localStorage.getItem(keyAuthFor(oldUsername)) || '{}');
             const settingsData = JSON.parse(localStorage.getItem(keySettingsFor(oldUsername)) || '{}');
-            const appData = JSON.parse(localStorage.getItem(keyFor(oldUsername)) || '{}');
+
+            // Move data in masterState
+            if (masterState[oldUsername]) {
+              masterState[newUsername] = masterState[oldUsername];
+              delete masterState[oldUsername];
+            }
 
             localStorage.setItem(keyAuthFor(newUsername), JSON.stringify(authData));
             localStorage.setItem(keySettingsFor(newUsername), JSON.stringify(settingsData));
-            localStorage.setItem(keyFor(newUsername), JSON.stringify(appData));
             
             localStorage.removeItem(keyAuthFor(oldUsername));
             localStorage.removeItem(keySettingsFor(oldUsername));
-            localStorage.removeItem(keyFor(oldUsername));
+            localStorage.removeItem(keyFor(oldUsername)); // Keep this for cleanup from older versions
 
             const newUserList = usersList.map(u => u === oldUsername ? newUsername : u);
             localStorage.setItem(KEY_USERS, JSON.stringify(newUserList));
             
             currentUser = newUsername;
+            persist(); // Save the user rename in the sheet
           }
 
           const auth = JSON.parse(localStorage.getItem(keyAuthFor(currentUser)) || '{}');
@@ -325,17 +335,23 @@
       wizard[0]()
     }
     
-    async function loadForCurrentUser(){
+    function loadForCurrentUser(){
       if(!currentUser) return;
       settings = JSON.parse(localStorage.getItem(keySettingsFor(currentUser)) || JSON.stringify(defaultSettings));
-      await initGapi();
-      state = await loadDataFromSheet();
+
+      if (!masterState[currentUser]) {
+        masterState[currentUser] = { customers: [] };
+        persist(); // Create and save the new user's data structure
+      }
+      state = masterState[currentUser];
+
       document.getElementById('currentClub').textContent = settings.clubName ? settings.clubName : '';
       logoutContainer.style.display = 'block';
       renderList();
     }
 
-    function init(){
+    async function init(){
+      await initGapiAndLoad(); // Load all data from sheet first
       const usersList = JSON.parse(localStorage.getItem(KEY_USERS) || '[]')
       if (usersList.length === 0) {
         const randomUser = 'user_' + uid().slice(0, 4);
@@ -345,7 +361,7 @@
         localStorage.setItem(KEY_USERS, JSON.stringify(usersList));
         localStorage.setItem(keyAuthFor(randomUser), JSON.stringify({ username: randomUser, password: randomPass }));
         localStorage.setItem(keySettingsFor(randomUser), JSON.stringify({ ...defaultSettings, setupComplete: false }));
-        localStorage.setItem(keyFor(randomUser), JSON.stringify({ customers: [] }));
+        // No longer creating user data in localStorage, it will be created in masterState on first login
 
         showModal(`
           <div style='text-align:center'>
@@ -403,12 +419,6 @@
               <div><label>قیمت ۳ ماهه</label><input id='s_threeMonth' type='number' value="${settings.threeMonthPrice}"></div>
               <div style='grid-column:span 2'><label>تغییر پسورد</label><input id='sPass' type='password' placeholder='اگر نمی‌خواهید تغییر دهید خالی بگذارید' /></div>
       
-              <div style='grid-column:span 2; border-top: 1px solid rgba(255,255,255,0.1); padding-top: 12px; margin-top: 8px;'>
-                  <h4>تنظیمات Google Sheets</h4>
-                  <p class='muted' style='font-size:12px'>برای ذخیره داده‌ها در Google Sheet، اطلاعات زیر را وارد کنید.</p>
-              </div>
-              <div><label>API Key</label><input id='s_apiKey' value="${escapeHtml(settings.apiKey || '')}"></div>
-              <div><label>Sheet ID</label><input id='s_sheetId' value="${escapeHtml(settings.sheetId || '')}"></div>
           </div>
           <div style='margin-top:16px; display:flex; justify-content:flex-end; gap:8px;'>
                 <button class='btn warn' id='doDeleteAll'>حذف همه مشتریان</button>
@@ -423,8 +433,6 @@
             settings.oneMonthPrice = Number(document.getElementById('s_oneMonth').value);
             settings.twoMonthPrice = Number(document.getElementById('s_twoMonth').value);
             settings.threeMonthPrice = Number(document.getElementById('s_threeMonth').value);
-            settings.apiKey = document.getElementById('s_apiKey').value.trim();
-            settings.sheetId = document.getElementById('s_sheetId').value.trim();
             const newPass = document.getElementById('sPass').value.trim(); if(newPass){ const auth = JSON.parse(localStorage.getItem(`gm_auth_${currentUser}`)||'{}'); auth.password = newPass; localStorage.setItem(`gm_auth_${currentUser}`, JSON.stringify(auth)); }
         
             localStorage.setItem(keySettingsFor(currentUser), JSON.stringify(settings));
@@ -496,7 +504,7 @@
         </div>
       </div>`; detailsArea.appendChild(wrapper);
       document.getElementById('btnVisit').addEventListener('click', ()=> openVisitModal(c)); document.getElementById('btnPayment').addEventListener('click', ()=> openPaymentModal(c)); document.getElementById('btnBuffet').addEventListener('click', ()=> openBuffetModal(c)); document.getElementById('btnEdit').addEventListener('click', ()=> openEditModal(c));}
-    function persist(){ saveDataToSheet() }
+    function persist(){ saveMasterStateToSheet() }
     btnAdd.addEventListener('click', ()=> openAddModal())
     function openAddModal(){ showModal(`<h3>ثبت مشتری جدید</h3><div style='display:flex;gap:8px;flex-wrap:wrap;margin-top:8px'><div style='flex:1;min-width:200px'><label>نام</label><input id='fName' /></div><div style='flex:1;min-width:160px'><label>شماره</label><input id='fPhone' /></div></div><div style='margin-top:8px'><label>نوع</label><select id='fType'><option value='single'>تک‌جلسه‌ای</option><option value='subscription'>دوره‌ای</option></select></div><div id='subSettings' style='margin-top:8px;display:none'><label>مدت دوره</label><select id='fDuration'><option value='1'>یک ماهه</option><option value='2'>دو ماهه</option><option value='3'>سه ماهه</option></select><div style='display:flex;gap:8px;margin-top:8px'><div style='flex:1'><label>تعداد کل جلسات (خالی=پیش‌فرض)</label><input id='fTotalSessions' type='number' /></div></div></div><div style='margin-top:12px;display:flex;gap:8px;justify-content:flex-end'><button class='btn' id='saveNew'>ذخیره</button><button class='btn ghost' id='cancelNew'>انصراف</button></div>`);
       const fType = document.getElementById('fType'); const subSettings = document.getElementById('subSettings'); fType.addEventListener('change', ()=> { subSettings.style.display = fType.value==='subscription' ? 'block' : 'none' }); document.getElementById('cancelNew').addEventListener('click', closeModal); document.getElementById('saveNew').addEventListener('click', ()=>{
@@ -519,74 +527,55 @@
     function openEditModal(c){ showModal(`<h3>ویرایش — ${escapeHtml(c.name)}</h3><div style='display:flex;gap:8px;flex-wrap:wrap'><div style='flex:1'><label>نام</label><input id='eName' value='${escapeHtml(c.name)}' /></div><div style='flex:1'><label>شماره</label><input id='ePhone' value='${escapeHtml(c.phone)}' /></div></div><div style='margin-top:8px'><label>یادداشت</label><textarea id='eNotes'>${escapeHtml(c.notes||'')}</textarea></div><div style='margin-top:12px;display:flex;gap:8px;justify-content:flex-end'><button class='btn' id='saveEdit'>ذخیره</button><button class='btn warn' id='delCustomer'>حذف</button><button class='btn ghost' id='cancelEdit'>انصراف</button></div>`);
       document.getElementById('cancelEdit').addEventListener('click', closeModal); document.getElementById('delCustomer').addEventListener('click', ()=>{ if(!confirm('آیا از حذف این مشتری مطمئن هستید؟ این عمل غیرقابل بازگشت است.')) return; state.customers = state.customers.filter(x=>x.id!==c.id); persist(); renderList(); closeModal(); document.getElementById('detailsArea').innerHTML='<div class="muted">مشتری حذف شد.</div>' }); document.getElementById('saveEdit').addEventListener('click', ()=>{ c.name = document.getElementById('eName').value.trim(); c.phone = document.getElementById('ePhone').value.trim(); c.notes = document.getElementById('eNotes').value; persist(); renderList(); renderCustomerDetails(c); closeModal() }) }
 
-
     // --- Google Sheets API Functions ---
-    async function initGapi() {
-        if (!settings.apiKey) {
-            console.warn("API Key is not set. Google Sheets integration is disabled.");
-            return;
-        }
+    async function initGapiAndLoad() {
         await new Promise((resolve) => gapi.load('client', resolve));
         await gapi.client.init({
-            apiKey: settings.apiKey,
+            apiKey: API_KEY,
             discoveryDocs: ["https://sheets.googleapis.com/$discovery/rest?version=v4"],
         });
+        masterState = await loadMasterStateFromSheet();
     }
 
-    async function loadDataFromSheet() {
-        if (!settings.sheetId || !gapi.client.sheets) {
-            console.log("Sheet ID is not set or GAPI not initialized. Loading from localStorage.");
-            return JSON.parse(localStorage.getItem(keyFor(currentUser)) || JSON.stringify({customers:[]}));
-        }
+    async function loadMasterStateFromSheet() {
         try {
             const response = await gapi.client.sheets.spreadsheets.values.get({
-                spreadsheetId: settings.sheetId,
-                range: 'A1:A1', // Check if sheet is empty
-            });
-
-            if (!response.result.values || response.result.values.length === 0) {
-                 console.log("Sheet is empty. Starting with a fresh state.");
-                 return { customers: [] };
-            }
-
-            const dataResponse = await gapi.client.sheets.spreadsheets.values.get({
-                spreadsheetId: settings.sheetId,
+                spreadsheetId: SPREADSHEET_ID,
                 range: 'A1',
             });
-            const data = JSON.parse(dataResponse.result.values[0][0]);
-            console.log("Data loaded from Google Sheet:", data);
-            return data;
+
+            if (response.result.values && response.result.values.length > 0) {
+                const data = JSON.parse(response.result.values[0][0]);
+                console.log("Master state loaded from Google Sheet:", data);
+                return data;
+            } else {
+                console.log("Sheet is empty. Initializing a new master state.");
+                return {}; // Return empty object if sheet is empty
+            }
         } catch (err) {
-            console.error("Error loading data from Google Sheet:", err);
-            alert('خطا در بارگیری اطلاعات از گوگل شیت. از آخرین نسخه ذخیره شده در مرورگر استفاده می‌شود.');
-            return JSON.parse(localStorage.getItem(keyFor(currentUser)) || JSON.stringify({customers:[]}));
+            console.error("Fatal Error: Could not load data from Google Sheet.", err);
+            showModal(`<h3>خطای بحرانی</h3><p>امکان بارگیری اطلاعات از سرور وجود ندارد. لطفاً از درستی تنظیمات مطمئن شده و صفحه را رفرش کنید.</p><p style="font-size:12px; color: var(--muted);">${err.message}</p>`);
+            return {}; // Return empty object on error to prevent total crash
         }
     }
 
-    async function saveDataToSheet() {
-        if (!settings.sheetId || !gapi.client.sheets) {
-            console.log("Sheet ID is not set or GAPI not initialized. Saving to localStorage.");
-            localStorage.setItem(keyFor(currentUser), JSON.stringify(state));
-            return;
-        }
+    async function saveMasterStateToSheet() {
         try {
-            const data = JSON.stringify(state);
+            const data = JSON.stringify(masterState);
             await gapi.client.sheets.spreadsheets.values.update({
-                spreadsheetId: settings.sheetId,
+                spreadsheetId: SPREADSHEET_ID,
                 range: 'A1',
                 valueInputOption: 'RAW',
                 resource: {
                     values: [[data]]
                 }
             });
-            console.log("Data saved to Google Sheet.");
+            console.log("Master state saved to Google Sheet.");
         } catch (err) {
-            console.error("Error saving data to Google Sheet:", err);
-            alert('خطا در ذخیره اطلاعات در گوگل شیت. اطلاعات در مرورگر شما ذخیره شد.');
-            localStorage.setItem(keyFor(currentUser), JSON.stringify(state));
+            console.error("Fatal Error: Could not save data to Google Sheet.", err);
+            showModal(`<h3>خطای بحرانی</h3><p>امکان ذخیره اطلاعات در سرور وجود ندارد. تغییرات اخیر شما ذخیره نشده است. لطفاً صفحه را رفرش کرده و دوباره تلاش کنید.</p><p style="font-size:12px; color: var(--muted);">${err.message}</p>`);
         }
     }
-
 
     // Start the app
     init();


### PR DESCRIPTION
This commit refactors the application to use a single, centralized Google Sheet for all user data, as per the new requirements. The previous `localStorage`-based and per-user Google Sheet implementations have been replaced.

Key changes include:
- Hardcoding the provided Google Sheets API Key and Spreadsheet ID.
- Introducing a `masterState` object to manage data for all users in a multi-tenant fashion within a single data store.
- Modifying the application's startup sequence (`init`) to load the entire `masterState` from the sheet.
- Updating the `persist` function to save the entire `masterState` back to the sheet on any data modification.
- Removing all `localStorage` usage for customer data, which is now exclusively handled by the Google Sheet.
- Removing the API configuration UI from the settings modal as it's no longer needed.